### PR TITLE
finished journal index page with minor changes to nav css

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -1,5 +1,6 @@
 .button {
   border: 1px solid black;
+  background-color: white;
   border-radius: 10px;
   text-align: center;
   margin: 10px;

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -5,3 +5,9 @@
 @import "navbar";
 @import "buttons";
 @import "family_pet_card";
+@import "journal";
+
+
+.mobile-margins {
+  margin-top: 70px;
+}

--- a/app/assets/stylesheets/components/_journal.scss
+++ b/app/assets/stylesheets/components/_journal.scss
@@ -1,0 +1,71 @@
+
+.journal-index .button {
+  position: fixed;
+  z-index: 999;
+  margin: 0;
+  top: 1rem;
+  left: 1rem;
+}
+
+
+.journal-container h2 {
+  font-size: 18px;
+}
+
+.journal-container p {
+  font-size: 16px;
+  margin: 10px 0px 10px 0px;
+}
+
+.user-name {
+  margin: 0;
+}
+
+.user-and-date {
+  padding: 5px 0px 0px 15px;
+}
+
+.journal-date {
+  margin: 0;
+}
+
+.journal-container {
+  overflow: auto;
+  width: 275px;
+  border: 1px solid black;
+  border-radius: 10px;
+  margin: 0 auto;
+  background-color: white;
+}
+
+.journal-top {
+  padding: 10px 5px;
+  display: flex;
+}
+
+.journal-user {
+  height: 50px;
+  width: 50px;
+  border-radius: 50%;
+}
+
+.see-more {
+  color: $d-purple;
+  cursor: pointer;
+  display: inline;
+}
+
+.journal-content {
+  padding: 5px 15px;
+}
+.more-text {
+  display: none;
+}
+
+.journal-photo {
+  width: 100%;
+  height: 275px;
+  object-fit: cover;
+  border-top: solid 1px;
+  display: block;
+}

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -7,6 +7,7 @@
   width: 100vw;
   position: fixed;
   display: none;
+  margin-top: -70px;
 }
 nav {
   position: fixed;
@@ -18,12 +19,11 @@ nav {
 .pet-icon-container {
  display: flex;
  justify-content: flex-end;
-
 }
 
 .current-pet-icon {
-  height: 40px;
-  width: 40px;
+  height: 45px;
+  width: 45px;
   border-radius: 50%;
   border: solid 1px;
   cursor: pointer;

--- a/app/controllers/journal_entries_controller.rb
+++ b/app/controllers/journal_entries_controller.rb
@@ -1,6 +1,6 @@
 class JournalEntriesController < ApplicationController
   def index
-    @journals = policy_scope(Journal).order(created_at: :desc)
-    @journals_as_owner = current_user.journals_as_owner
+    @journals = policy_scope(JournalEntry).order(created_at: :desc)
+    @journals_as_owner = current_user.journal_entries_as_owner
   end
 end

--- a/app/javascript/packs/seemore.js
+++ b/app/javascript/packs/seemore.js
@@ -1,0 +1,11 @@
+const seeMore = document.querySelector('.see-more');
+const moreText = document.querySelector('.more-text');
+
+seeMore.addEventListener('click', () => {
+  if (moreText.style.display === "none") {
+    seeMore.style.display = "none";
+    moreText.style.display = "inline";
+  } else {
+    moreText.style.display = "none";
+  }
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,6 @@ class User < ApplicationRecord
   has_many :appointments, through: :pets
 
   has_one_attached :photo
+
+  has_many :journal_entries_as_owner, through: :pets, source: :journal_entries
 end

--- a/app/policies/journal_entry_policy.rb
+++ b/app/policies/journal_entry_policy.rb
@@ -1,0 +1,8 @@
+class JournalEntryPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/views/journal_entries/index.html.erb
+++ b/app/views/journal_entries/index.html.erb
@@ -1,0 +1,29 @@
+<div class="journal-index">
+  <%= render 'shared/buttons/backbtn' %>
+</div>
+
+
+<% @journals_as_owner.each do |journal| %>
+  <div class="journal-container mobile-margins">
+    <div class="journal-top">
+      <%= cl_image_tag(journal.pet.ownerships.first.user.photo.key, class: "journal-user") %>
+      <div class="user-and-date">
+        <h2 class="user-name"> <%= journal.pet.ownerships.first.user.name %></h2>
+        <small class="journal-date"> <%= journal.created_at.to_formatted_s(:short) %> </small>
+      </div>
+    </div>
+    <div class="journal-content">
+      <h2 class="journal-title">
+        <b> <%= journal.name %></b>
+      </h2>
+      <p class="journal-entry">
+      Making my way downtown. Walking fast Faces pass. And Im home-bound <span class="see-more"><b>See More </b></span><span class="more-text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet, nulla et dictum interdum, nisi lorem egestas vitae sce</span>
+      </p>
+    </div>
+    <div class="journal-img">
+      <img class="journal-photo" src="https://vetstreet.brightspotcdn.com/dims4/default/18f82ff/2147483647/thumbnail/645x380/quality/90/?url=https%3A%2F%2Fvetstreet-brightspot.s3.amazonaws.com%2F1e%2F1c6420a7f811e0a0d50050568d634f%2Ffile%2FPoodle-miniature-1-645mk062811.jpg" alt="">
+    </div>
+  </div>
+<% end %>
+
+<%= javascript_pack_tag 'seemore'%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,9 @@
   </head>
 
   <body>
-  <%= render 'shared/navbar' %>
-    <div class="container">
-      <%= yield %>
-    </div>
+    <%= render 'shared/navbar' %>
+      <div class="container">
+        <%= yield %>
+      </div>
   </body>
 </html>

--- a/test/policies/journal_entry_policy_test.rb
+++ b/test/policies/journal_entry_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class JournalEntryPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
!!Please Read!!


Because Jessica needs this page to work in order to do anything, I am pushing it at a 70% complete state. There is nothing visually wrong with it, however, there are a few things that need to be adjusted as listed below↓

**things that are not completed on this page:** 
- the image displaying right now is journal.pet.ownerships.first.user.photo , meaning its just showing the first person who /owns/ this pet. i might have to redo the seeds to have a user id attached upon creation. 

- journal.content has not been updated, @k-ashmore said he knew how to redo this display using object-fit(i think) thus I shall leave that specific part to you. 

- The javascript expand only works for the first see more, fixing this is lower priority as ken may get rid of that all due to the previous bullet point.

- the back button does not work (theres no page to go back to until tyler finishes his pets dashboard, ill link it later). im also going to add a white background so it doesnt look too weird upon scrolling but is /always/ accessible but this is not a journal entries only thing.

**new CSS helper class created** 
- if you user ".mobile-margins" at the begging of any file it'll add a margin-top like in the picture. this may need to be adjusted for pages with a button and pages without as the button does take up space throwing the margin calculations off. 

![Screen Shot 2022-08-12 at 1 35 23](https://user-images.githubusercontent.com/74501096/184184811-c50cda03-1a89-4f69-9729-d6804a211fbf.png)

this is... definitely my most detailed pull request ever lol

