### PR TITLE
you can now see all journal entries for one pet, no matter the user

### DIFF
--- a/app/controllers/journal_entries_controller.rb
+++ b/app/controllers/journal_entries_controller.rb
@@ -1,8 +1,8 @@
 class JournalEntriesController < ApplicationController
   def index
     @journals = policy_scope(JournalEntry)
-    @journals_as_owner = current_user.journal_entries_as_owner.order(created_at: :desc)
     @pet = Pet.find(params[:pet_id])
+    @journal_entries = @pet.journal_entries.order(created_at: :desc)
   end
 
   def new

--- a/app/views/journal_entries/index.html.erb
+++ b/app/views/journal_entries/index.html.erb
@@ -7,7 +7,7 @@
   <% end %>
 </div>
 
-<% @journals_as_owner.each do |journal| %>
+<% @journal_entries.each do |journal| %>
   <div class="journal-container mobile-margins">
     <div class="journal-top">
       <%= cl_image_tag(journal.pet.ownerships.first.user.photo.key, class: "journal-user") %>


### PR DESCRIPTION
fixed this : 
when you click on a pet's journal entries it will display journals for all of your pets instead of the pet you are currently accessing